### PR TITLE
feat(print): add message when there's nothing to print

### DIFF
--- a/main.go
+++ b/main.go
@@ -232,13 +232,10 @@ func decodeRelease(data string) (*rspb.Release, error) {
 
 func print(releases []releaseData) {
 	if len(releases) == 0 {
+		fmt.Println("Nothing to show (try using a wider time range or a different namespace)")
 		return
 	}
 
-	fmt.Println((string)(formatAsTable(releases)))
-}
-
-func formatAsTable(releases []releaseData) []byte {
 	tbl := uitable.New()
 
 	tbl.MaxColWidth = 60
@@ -247,7 +244,8 @@ func formatAsTable(releases []releaseData) []byte {
 		r := releases[i]
 		tbl.AddRow(r.name, r.revision, r.updated, r.status, r.chart, r.namespace)
 	}
-	return tbl.Bytes()
+
+	fmt.Println(tbl.String())
 }
 
 func getClientSet(kubeContext string) *kubernetes.Clientset {


### PR DESCRIPTION
Add a print message when the release data size returned is 0.

Also, clean up the print function a bit

Closes #3 

Signed-off-by: Hagai Barel <hagaibarel@gmail.com>